### PR TITLE
Fix HMAC verification timing

### DIFF
--- a/utils/hmac.js
+++ b/utils/hmac.js
@@ -14,5 +14,22 @@ export function sign(data, secret) {
  */
 export function verify(data, secret, signature) {
   const expected = sign(data, secret);
-  return expected === signature;
+
+  if (typeof signature !== 'string') {
+    return false;
+  }
+
+  const provided = signature.toLowerCase();
+  const valid = expected.toLowerCase();
+
+  if (provided.length !== valid.length) {
+    return false;
+  }
+
+  let diff = 0;
+  for (let i = 0; i < valid.length; i++) {
+    diff |= valid.charCodeAt(i) ^ provided.charCodeAt(i);
+  }
+
+  return diff === 0;
 }


### PR DESCRIPTION
## Summary
- make HMAC verification case-insensitive
- compare signatures in constant time to avoid timing attacks

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68473397842c832c8318c103846a5715